### PR TITLE
adds logger to log the number of reticulation nodes

### DIFF
--- a/src/speciesnetwork/utils/ReticulationLogger.java
+++ b/src/speciesnetwork/utils/ReticulationLogger.java
@@ -1,0 +1,41 @@
+package speciesnetwork.utils;
+
+import java.io.PrintStream;
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
+
+import beast.core.BEASTObject;
+import beast.core.Description;
+import beast.core.Input;
+import beast.core.Input.Validate;
+import beast.core.Loggable;
+import speciesnetwork.Network;
+
+@Description("Logs backbone tree annotated with metadata")
+public class ReticulationLogger extends BEASTObject implements Loggable {
+    public final Input<Network> speciesNetworkInput =
+            new Input<>("speciesNetwork", "The species network to be logged.", Validate.REQUIRED);
+
+
+    @Override
+    public void initAndValidate() {
+    	
+    }
+
+    @Override
+    public void init(PrintStream out) {
+        final Network speciesNetwork = speciesNetworkInput.get();
+        out.print(speciesNetwork.getID() + ".reticulationNodes\t");
+        
+    }
+
+    @Override
+    public void log(long sample, PrintStream out) {
+        final Network speciesNetwork = speciesNetworkInput.get();
+    	out.print(speciesNetwork.getReticulationNodeCount() + "\t");
+    }
+
+    @Override
+    public void close(PrintStream out) {
+    }
+}


### PR DESCRIPTION
I've added a small logger class that allows to log the number of reticulation nodes at any point in the MCMC and can be used  to log node counts to regular *.log files